### PR TITLE
Debian gnutls-utils became gnutls-bin

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,7 +175,7 @@
         $ sudo apt install libgnutls28-dev
         $ sudo apt install uuid-dev
         $ sudo apt install cmake
-        $ sudo apt install gnutls-utils
+        $ sudo apt install gnutls-bin
         </code></pre>
       </section>
       <section>


### PR DESCRIPTION
The certtool is in Debian package gnutls-bin,
there is no gnutls-utils.